### PR TITLE
Resolve #13

### DIFF
--- a/web/foi_requests/admin.py
+++ b/web/foi_requests/admin.py
@@ -221,5 +221,5 @@ class MessageAdmin(admin.ModelAdmin):
         return self.readonly_fields + extra_readonly_fields
 
 
-admin.site.register(PublicBody, search_fields=["name"])
+admin.site.register(PublicBody, search_fields=['name'])
 admin.site.register(Esic)

--- a/web/foi_requests/admin.py
+++ b/web/foi_requests/admin.py
@@ -77,6 +77,7 @@ class MessageInline(admin.StackedInline):
         })
     )
     ordering = ['created_at']
+    autocomplete_fields = ('sender', 'receiver')
 
 
 @admin.register(FOIRequest)
@@ -220,5 +221,5 @@ class MessageAdmin(admin.ModelAdmin):
         return self.readonly_fields + extra_readonly_fields
 
 
-admin.site.register(PublicBody)
+admin.site.register(PublicBody, search_fields=["name"])
 admin.site.register(Esic)


### PR DESCRIPTION
Possibilita a busca por nome nas ForeignKeys de sender e receiver no admin do modelo Message.

Descobri que a partir do Django 2.0 já é possibilitado isso por default: https://github.com/django/django/pull/6385/files

![screen shot 2019-02-21 at 17 28 16](https://user-images.githubusercontent.com/8164573/53199543-1c0ba000-35fe-11e9-9d81-7eb3a4d9247b.png)

Resolve #13 